### PR TITLE
Added fonts-noto-color-emoji package

### DIFF
--- a/desktop-amd64
+++ b/desktop-amd64
@@ -17,6 +17,7 @@ dpkg-dev
 flac
 filelight
 fonts-hack-ttf
+fonts-noto-color-emoji
 fonts-noto-hinted
 superx-fonts
 fonts-symbola


### PR DESCRIPTION
Installs Google's color emoji font `noto color emoji`. Required for websites relying on the font and can't be used by CSS/Webfont, has to be installed by system.